### PR TITLE
feat(material): use central workload authentication

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <SharedLibraryVersion Condition="'$(SharedLibraryVersion)' == ''">1.0.*-alpha*</SharedLibraryVersion>
+    <ServiceDefaultsVersion Condition="'$(ServiceDefaultsVersion)' == ''">1.0.89-alpha</ServiceDefaultsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />

--- a/Maliev.MaterialService.Api/Controllers/MaterialsController.cs
+++ b/Maliev.MaterialService.Api/Controllers/MaterialsController.cs
@@ -107,6 +107,7 @@ public class MaterialsController : ControllerBase
     [RequirePermission(MaterialPermissions.MaterialsCreate)]
     [ProducesResponseType(typeof(MaterialResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<MaterialResponse>> CreateMaterial(
         [FromBody] CreateMaterialRequest request,
         CancellationToken cancellationToken)
@@ -128,6 +129,13 @@ public class MaterialsController : ControllerBase
             _logger.LogWarning(ex, "Failed to create material");
             return BadRequest(new { message = ex.Message });
         }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Supplier validation is unavailable while creating material");
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { message = "Supplier validation is temporarily unavailable." });
+        }
     }
 
     /// <summary>
@@ -146,6 +154,7 @@ public class MaterialsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<MaterialResponse>> UpdateMaterial(
         Guid id,
         [FromBody] UpdateMaterialRequest request,
@@ -178,6 +187,13 @@ public class MaterialsController : ControllerBase
                 return Conflict(new { message = ex.Message });
             }
             return BadRequest(new { message = ex.Message });
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Supplier validation is unavailable while updating material {MaterialId}", id);
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { message = "Supplier validation is temporarily unavailable." });
         }
     }
 

--- a/Maliev.MaterialService.Api/Controllers/MaterialsController.cs
+++ b/Maliev.MaterialService.Api/Controllers/MaterialsController.cs
@@ -107,14 +107,16 @@ public class MaterialsController : ControllerBase
     [RequirePermission(MaterialPermissions.MaterialsCreate)]
     [ProducesResponseType(typeof(MaterialResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<MaterialResponse>> CreateMaterial([FromBody] CreateMaterialRequest request)
+    public async Task<ActionResult<MaterialResponse>> CreateMaterial(
+        [FromBody] CreateMaterialRequest request,
+        CancellationToken cancellationToken)
     {
         _logger.LogInformation("Creating new material with code: {Code}", request.Code);
 
         try
         {
             var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "System";
-            var material = await _materialService.CreateMaterialAsync(request, userId);
+            var material = await _materialService.CreateMaterialAsync(request, userId, cancellationToken);
 
             return CreatedAtAction(
                 nameof(GetMaterialById),
@@ -144,14 +146,17 @@ public class MaterialsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<ActionResult<MaterialResponse>> UpdateMaterial(Guid id, [FromBody] UpdateMaterialRequest request)
+    public async Task<ActionResult<MaterialResponse>> UpdateMaterial(
+        Guid id,
+        [FromBody] UpdateMaterialRequest request,
+        CancellationToken cancellationToken)
     {
         _logger.LogInformation("Updating material with ID: {MaterialId}", id);
 
         try
         {
             var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "System";
-            var material = await _materialService.UpdateMaterialAsync(id, request, userId);
+            var material = await _materialService.UpdateMaterialAsync(id, request, userId, cancellationToken);
 
             if (material == null)
             {

--- a/Maliev.MaterialService.Api/Maliev.MaterialService.Api.csproj
+++ b/Maliev.MaterialService.Api/Maliev.MaterialService.Api.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
     <PackageReference Include="Maliev.MessagingContracts" Version="$(SharedLibraryVersion)" />
   </ItemGroup>
 

--- a/Maliev.MaterialService.Api/Program.cs
+++ b/Maliev.MaterialService.Api/Program.cs
@@ -29,7 +29,8 @@ try
     });
     builder.AddServiceMeters("materials-meter"); // Register service meters for OpenTelemetry business metrics
 
-    builder.AddIAMServiceClient("material");
+    builder.AddAuthServiceTokenExchange("MaterialService");
+    builder.AddAuthServiceIAMClient();
     builder.Services.AddIAMRegistration<MaterialIAMRegistrationService>("material");
 
     // Core application services
@@ -69,7 +70,9 @@ try
             description: "Material inventory management service. Provides CRUD operations for materials with supplier associations, bulk import/export capabilities, supplier validation, reference data for categories and units, and cached responses for high-performance lookups.");
     }
 
-    builder.AddServiceClient<Maliev.MaterialService.Application.Services.ISupplierServiceClient, Maliev.MaterialService.Infrastructure.Services.SupplierServiceClient>("SupplierService");
+    builder.AddServiceClient<ISupplierServiceClient, SupplierServiceClient>("SupplierService")
+        .AddAuthServiceAuthentication()
+        .AddStandardResilienceHandler();
 
     builder.Services.AddScoped<IMaterialService, Maliev.MaterialService.Infrastructure.Services.MaterialService>();
     builder.Services.AddScoped<IBulkMaterialService, Maliev.MaterialService.Infrastructure.Services.BulkMaterialService>();

--- a/Maliev.MaterialService.Application/Maliev.MaterialService.Application.csproj
+++ b/Maliev.MaterialService.Application/Maliev.MaterialService.Application.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.MaterialService.Application/Services/IMaterialService.cs
+++ b/Maliev.MaterialService.Application/Services/IMaterialService.cs
@@ -13,8 +13,12 @@ public interface IMaterialService
     /// </summary>
     /// <param name="request">Material creation request.</param>
     /// <param name="userId">ID of the user creating the material.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The created material.</returns>
-    Task<MaterialResponse> CreateMaterialAsync(CreateMaterialRequest request, string userId);
+    Task<MaterialResponse> CreateMaterialAsync(
+        CreateMaterialRequest request,
+        string userId,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves a material by its ID.
@@ -29,8 +33,13 @@ public interface IMaterialService
     /// <param name="id">Material ID.</param>
     /// <param name="request">Update request.</param>
     /// <param name="userId">ID of the user updating the material.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The updated material if found, null otherwise.</returns>
-    Task<MaterialResponse?> UpdateMaterialAsync(Guid id, UpdateMaterialRequest request, string userId);
+    Task<MaterialResponse?> UpdateMaterialAsync(
+        Guid id,
+        UpdateMaterialRequest request,
+        string userId,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a material (soft delete).

--- a/Maliev.MaterialService.Application/Services/ISupplierServiceClient.cs
+++ b/Maliev.MaterialService.Application/Services/ISupplierServiceClient.cs
@@ -9,6 +9,9 @@ public interface ISupplierServiceClient
     /// Validates whether a supplier exists in the Supplier Service.
     /// </summary>
     /// <param name="supplierId">The supplier ID to validate.</param>
+    /// <param name="cancellationToken">Cancellation token for the outbound request.</param>
     /// <returns>True if the supplier exists, false otherwise.</returns>
-    Task<bool> ValidateSupplierExistsAsync(Guid supplierId);
+    Task<bool> ValidateSupplierExistsAsync(
+        Guid supplierId,
+        CancellationToken cancellationToken = default);
 }

--- a/Maliev.MaterialService.Application/Services/ISupplierServiceClient.cs
+++ b/Maliev.MaterialService.Application/Services/ISupplierServiceClient.cs
@@ -6,12 +6,19 @@ namespace Maliev.MaterialService.Application.Services;
 public interface ISupplierServiceClient
 {
     /// <summary>
-    /// Validates whether a supplier exists in the Supplier Service.
+    /// Gets the authoritative active Supplier projection required by MaterialService.
     /// </summary>
     /// <param name="supplierId">The supplier ID to validate.</param>
     /// <param name="cancellationToken">Cancellation token for the outbound request.</param>
-    /// <returns>True if the supplier exists, false otherwise.</returns>
-    Task<bool> ValidateSupplierExistsAsync(
+    /// <returns>The active supplier projection, or null when SupplierService returns not found.</returns>
+    Task<SupplierReference?> GetSupplierAsync(
         Guid supplierId,
         CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Minimal authoritative SupplierService data projected into MaterialService.
+/// </summary>
+/// <param name="Id">Supplier identifier.</param>
+/// <param name="CompanyName">Current supplier company name.</param>
+public sealed record SupplierReference(Guid Id, string CompanyName);

--- a/Maliev.MaterialService.Infrastructure/Maliev.MaterialService.Infrastructure.csproj
+++ b/Maliev.MaterialService.Infrastructure/Maliev.MaterialService.Infrastructure.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
     <PackageReference Include="Maliev.MessagingContracts" Version="$(SharedLibraryVersion)" />
   </ItemGroup>
 

--- a/Maliev.MaterialService.Infrastructure/Services/MaterialService.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/MaterialService.cs
@@ -82,7 +82,8 @@ public class MaterialService : IMaterialService
             throw new InvalidOperationException($"Material with code '{request.Code}' already exists.");
         }
 
-        await ValidateSupplierAsync(request.SupplierId, cancellationToken);
+        var supplier = await GetSupplierProjectionAsync(request.SupplierId, cancellationToken);
+        await UpsertSupplierProjectionAsync(supplier, userId, cancellationToken);
 
         var material = request.ToMaterial();
         material.Id = Guid.NewGuid();
@@ -181,6 +182,17 @@ public class MaterialService : IMaterialService
     {
         _logger.LogInformation("Updating material with ID: {MaterialId}", id);
 
+        var materialExists = await _context.Materials
+            .AsNoTracking()
+            .AnyAsync(material => material.Id == id && material.Active, cancellationToken);
+        if (!materialExists)
+        {
+            return null;
+        }
+
+        var supplier = await GetSupplierProjectionAsync(request.SupplierId, cancellationToken);
+        await UpsertSupplierProjectionAsync(supplier, userId, cancellationToken);
+
         var strategy = _context.Database.CreateExecutionStrategy();
 
         return await strategy.ExecuteAsync(async () =>
@@ -201,8 +213,6 @@ public class MaterialService : IMaterialService
                 {
                     return null;
                 }
-
-                await ValidateSupplierAsync(request.SupplierId, cancellationToken);
 
                 material.UpdateMaterial(request);
                 material.UpdatedBy = userId;
@@ -502,22 +512,50 @@ public class MaterialService : IMaterialService
         }
     }
 
-    private async Task ValidateSupplierAsync(
+    private async Task<SupplierReference?> GetSupplierProjectionAsync(
         Guid? supplierId,
         CancellationToken cancellationToken)
     {
         if (!supplierId.HasValue)
         {
-            return;
+            return null;
         }
 
-        var supplierExists = await _supplierServiceClient.ValidateSupplierExistsAsync(
+        var supplier = await _supplierServiceClient.GetSupplierAsync(
             supplierId.Value,
             cancellationToken);
-        if (!supplierExists)
+        if (supplier is null)
         {
             throw new InvalidOperationException($"Supplier with ID '{supplierId.Value}' does not exist.");
         }
+
+        return supplier;
+    }
+
+    private async Task UpsertSupplierProjectionAsync(
+        SupplierReference? supplier,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        if (supplier is null)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        await _context.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+            INSERT INTO suppliers
+                (id, name, contact_info, created_at, created_by, updated_at, updated_by, active)
+            VALUES
+                ({supplier.Id}, {supplier.CompanyName}, {null}, {now}, {userId}, {null}, {null}, {true})
+            ON CONFLICT (id) DO UPDATE SET
+                name = EXCLUDED.name,
+                updated_at = EXCLUDED.created_at,
+                updated_by = EXCLUDED.created_by,
+                active = TRUE
+            """,
+            cancellationToken);
     }
 
     private async Task InvalidateCacheAsync(Guid? materialId = null)

--- a/Maliev.MaterialService.Infrastructure/Services/MaterialService.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/MaterialService.cs
@@ -22,6 +22,7 @@ public class MaterialService : IMaterialService
     private readonly MaterialDbContext _context;
     private readonly ICacheService _cacheService;
     private readonly IPublishEndpoint _publishEndpoint;
+    private readonly ISupplierServiceClient _supplierServiceClient;
     private readonly ILogger<MaterialService> _logger;
     private const string CacheKeyPrefix = "material:";
 
@@ -31,21 +32,27 @@ public class MaterialService : IMaterialService
     /// <param name="context">Database context.</param>
     /// <param name="cacheService">Cache service.</param>
     /// <param name="publishEndpoint">MassTransit publish endpoint.</param>
+    /// <param name="supplierServiceClient">Protected SupplierService client.</param>
     /// <param name="logger">Logger instance.</param>
     public MaterialService(
         MaterialDbContext context,
         ICacheService cacheService,
         IPublishEndpoint publishEndpoint,
+        ISupplierServiceClient supplierServiceClient,
         ILogger<MaterialService> logger)
     {
         _context = context;
         _cacheService = cacheService;
         _publishEndpoint = publishEndpoint;
+        _supplierServiceClient = supplierServiceClient;
         _logger = logger;
     }
 
     /// <inheritdoc/>
-    public async Task<MaterialResponse> CreateMaterialAsync(CreateMaterialRequest request, string userId)
+    public async Task<MaterialResponse> CreateMaterialAsync(
+        CreateMaterialRequest request,
+        string userId,
+        CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Creating new material with code: {Code}", request.Code);
 
@@ -68,12 +75,14 @@ public class MaterialService : IMaterialService
 
         var existingMaterial = await _context.Materials
             .AsNoTracking()
-            .FirstOrDefaultAsync(m => m.Code == request.Code);
+            .FirstOrDefaultAsync(m => m.Code == request.Code, cancellationToken);
 
         if (existingMaterial != null)
         {
             throw new InvalidOperationException($"Material with code '{request.Code}' already exists.");
         }
+
+        await ValidateSupplierAsync(request.SupplierId, cancellationToken);
 
         var material = request.ToMaterial();
         material.Id = Guid.NewGuid();
@@ -93,7 +102,7 @@ public class MaterialService : IMaterialService
         }
 
         _context.Materials.Add(material);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Material created successfully with ID: {MaterialId}", material.Id);
 
@@ -164,7 +173,11 @@ public class MaterialService : IMaterialService
     }
 
     /// <inheritdoc/>
-    public async Task<MaterialResponse?> UpdateMaterialAsync(Guid id, UpdateMaterialRequest request, string userId)
+    public async Task<MaterialResponse?> UpdateMaterialAsync(
+        Guid id,
+        UpdateMaterialRequest request,
+        string userId,
+        CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Updating material with ID: {MaterialId}", id);
 
@@ -172,7 +185,7 @@ public class MaterialService : IMaterialService
 
         return await strategy.ExecuteAsync(async () =>
         {
-            using var transaction = await _context.Database.BeginTransactionAsync();
+            using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
 
             try
             {
@@ -182,12 +195,14 @@ public class MaterialService : IMaterialService
                     .Include(m => m.PostProcessingMethods)
                     .Include(m => m.MechanicalProperties)
                     .AsSplitQuery()
-                    .FirstOrDefaultAsync(m => m.Id == id && m.Active);
+                    .FirstOrDefaultAsync(m => m.Id == id && m.Active, cancellationToken);
 
                 if (material == null)
                 {
                     return null;
                 }
+
+                await ValidateSupplierAsync(request.SupplierId, cancellationToken);
 
                 material.UpdateMaterial(request);
                 material.UpdatedBy = userId;
@@ -209,7 +224,7 @@ public class MaterialService : IMaterialService
                     });
                 }
 
-                await _context.SaveChangesAsync();
+                await _context.SaveChangesAsync(cancellationToken);
 
                 var version = (int)_context.Entry(material).Property<uint>("xmin").CurrentValue;
 
@@ -240,7 +255,7 @@ public class MaterialService : IMaterialService
                 await _publishEndpoint.Publish(
                     MaterialSearchDocumentMapper.ToUpsertEvent(material, DateTimeOffset.UtcNow));
 
-                await transaction.CommitAsync();
+                await transaction.CommitAsync(cancellationToken);
 
                 await InvalidateCacheAsync(id);
 
@@ -253,7 +268,7 @@ public class MaterialService : IMaterialService
                 {
                     try
                     {
-                        await transaction.RollbackAsync();
+                        await transaction.RollbackAsync(cancellationToken);
                     }
                     catch (Exception rbEx)
                     {
@@ -484,6 +499,24 @@ public class MaterialService : IMaterialService
             {
                 material.PostProcessingMethods.Add(method);
             }
+        }
+    }
+
+    private async Task ValidateSupplierAsync(
+        Guid? supplierId,
+        CancellationToken cancellationToken)
+    {
+        if (!supplierId.HasValue)
+        {
+            return;
+        }
+
+        var supplierExists = await _supplierServiceClient.ValidateSupplierExistsAsync(
+            supplierId.Value,
+            cancellationToken);
+        if (!supplierExists)
+        {
+            throw new InvalidOperationException($"Supplier with ID '{supplierId.Value}' does not exist.");
         }
     }
 

--- a/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Json;
 using Maliev.MaterialService.Application.Services;
 using Microsoft.Extensions.Logging;
 
@@ -24,29 +25,41 @@ public class SupplierServiceClient : ISupplierServiceClient
     }
 
     /// <inheritdoc/>
-    public async Task<bool> ValidateSupplierExistsAsync(
+    public async Task<SupplierReference?> GetSupplierAsync(
         Guid supplierId,
         CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync(
-            $"/supplier/v1/suppliers/{supplierId}",
+            $"/supplier/v1/suppliers/{supplierId}/validate",
             cancellationToken);
-
-        if (response.IsSuccessStatusCode)
-        {
-            return true;
-        }
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
-            return false;
+            return null;
         }
 
-        _logger.LogError(
-            "Supplier Service lookup failed for {SupplierId} with status {StatusCode}",
-            supplierId,
-            response.StatusCode);
         response.EnsureSuccessStatusCode();
-        throw new InvalidOperationException("Unreachable after EnsureSuccessStatusCode.");
+        var supplier = await response.Content.ReadFromJsonAsync<SupplierValidationResponse>(
+            cancellationToken);
+        if (supplier is null ||
+            supplier.Id != supplierId ||
+            string.IsNullOrWhiteSpace(supplier.CompanyName) ||
+            !supplier.IsActive)
+        {
+            _logger.LogError(
+                "Supplier Service returned an invalid projection for {SupplierId}",
+                supplierId);
+            throw new HttpRequestException(
+                "Supplier Service returned an invalid supplier projection.",
+                inner: null,
+                HttpStatusCode.BadGateway);
+        }
+
+        return new SupplierReference(supplier.Id, supplier.CompanyName);
     }
+
+    private sealed record SupplierValidationResponse(
+        Guid Id,
+        string CompanyName,
+        bool IsActive);
 }

--- a/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
@@ -21,34 +21,32 @@ public class SupplierServiceClient : ISupplierServiceClient
     {
         _httpClient = httpClient;
         _logger = logger;
-
-        _httpClient.Timeout = TimeSpan.FromSeconds(60);
     }
 
     /// <inheritdoc/>
-    public async Task<bool> ValidateSupplierExistsAsync(Guid supplierId)
+    public async Task<bool> ValidateSupplierExistsAsync(
+        Guid supplierId,
+        CancellationToken cancellationToken = default)
     {
-        try
+        using var response = await _httpClient.GetAsync(
+            $"/supplier/v1/suppliers/{supplierId}",
+            cancellationToken);
+
+        if (response.IsSuccessStatusCode)
         {
-            var response = await _httpClient.GetAsync($"suppliers/{supplierId}");
+            return true;
+        }
 
-            if (response.IsSuccessStatusCode)
-            {
-                return true;
-            }
-
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                return false;
-            }
-
-            _logger.LogError("Error calling Supplier Service. StatusCode: {StatusCode}", response.StatusCode);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
             return false;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Exception occurred while calling Supplier Service for ID {SupplierId}", supplierId);
-            return false;
-        }
+
+        _logger.LogError(
+            "Supplier Service lookup failed for {SupplierId} with status {StatusCode}",
+            supplierId,
+            response.StatusCode);
+        response.EnsureSuccessStatusCode();
+        throw new InvalidOperationException("Unreachable after EnsureSuccessStatusCode.");
     }
 }

--- a/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Maliev.MaterialService.Application.Services;
 using Microsoft.Extensions.Logging;
 
@@ -39,8 +40,23 @@ public class SupplierServiceClient : ISupplierServiceClient
         }
 
         response.EnsureSuccessStatusCode();
-        var supplier = await response.Content.ReadFromJsonAsync<SupplierValidationResponse>(
-            cancellationToken);
+        SupplierValidationResponse? supplier;
+        try
+        {
+            supplier = await response.Content.ReadFromJsonAsync<SupplierValidationResponse>(
+                cancellationToken);
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException)
+        {
+            _logger.LogError(
+                exception,
+                "Supplier Service returned a malformed projection for {SupplierId}",
+                supplierId);
+            throw new HttpRequestException(
+                "Supplier Service returned an invalid supplier projection.",
+                exception,
+                HttpStatusCode.BadGateway);
+        }
         if (supplier is null ||
             supplier.Id != supplierId ||
             string.IsNullOrWhiteSpace(supplier.CompanyName) ||

--- a/Maliev.MaterialService.Tests/Fixtures/IntegrationTestWebAppFactory.cs
+++ b/Maliev.MaterialService.Tests/Fixtures/IntegrationTestWebAppFactory.cs
@@ -1,14 +1,21 @@
+using Maliev.MaterialService.Application.Services;
 using Maliev.MaterialService.Infrastructure.Persistence;
 using Maliev.MaterialService.Tests.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
 
 namespace Maliev.MaterialService.Tests.Fixtures;
 
 public class IntegrationTestWebAppFactory : BaseIntegrationTestFactory<Program, MaterialDbContext>
 {
+    /// <summary>
+    /// Protected SupplierService boundary used by integration tests.
+    /// </summary>
+    public Mock<ISupplierServiceClient> SupplierServiceClientMock { get; } = CreateSupplierServiceClientMock();
+
     public override MaterialDbContext CreateDbContext()
     {
         var connectionString = GetConnectionString();
@@ -23,6 +30,7 @@ public class IntegrationTestWebAppFactory : BaseIntegrationTestFactory<Program, 
     {
         services.RemoveAll<DbContextOptions<MaterialDbContext>>();
         services.RemoveAll<MaterialDbContext>();
+        services.RemoveAll<ISupplierServiceClient>();
 
         services.AddScoped(provider =>
         {
@@ -30,6 +38,7 @@ public class IntegrationTestWebAppFactory : BaseIntegrationTestFactory<Program, 
             ConfigureDbContextOptions(optionsBuilder, GetConnectionString());
             return new MaterialDbContext(optionsBuilder.Options, metricsInterceptor: null);
         });
+        services.AddSingleton(SupplierServiceClientMock.Object);
     }
 
     private static void ConfigureDbContextOptions(
@@ -47,5 +56,15 @@ public class IntegrationTestWebAppFactory : BaseIntegrationTestFactory<Program, 
         return _postgresContainer?.GetConnectionString()
             ?? Environment.GetEnvironmentVariable($"ConnectionStrings__{DbConnectionStringName}")
             ?? throw new InvalidOperationException("Database connection string not found");
+    }
+
+    private static Mock<ISupplierServiceClient> CreateSupplierServiceClientMock()
+    {
+        var mock = new Mock<ISupplierServiceClient>();
+        mock.Setup(client => client.ValidateSupplierExistsAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return mock;
     }
 }

--- a/Maliev.MaterialService.Tests/Fixtures/IntegrationTestWebAppFactory.cs
+++ b/Maliev.MaterialService.Tests/Fixtures/IntegrationTestWebAppFactory.cs
@@ -61,10 +61,11 @@ public class IntegrationTestWebAppFactory : BaseIntegrationTestFactory<Program, 
     private static Mock<ISupplierServiceClient> CreateSupplierServiceClientMock()
     {
         var mock = new Mock<ISupplierServiceClient>();
-        mock.Setup(client => client.ValidateSupplierExistsAsync(
+        mock.Setup(client => client.GetSupplierAsync(
                 It.IsAny<Guid>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .ReturnsAsync((Guid supplierId, CancellationToken _) =>
+                new SupplierReference(supplierId, $"Supplier {supplierId:N}"));
         return mock;
     }
 }

--- a/Maliev.MaterialService.Tests/Integration/MaterialsControllerTests.cs
+++ b/Maliev.MaterialService.Tests/Integration/MaterialsControllerTests.cs
@@ -169,10 +169,10 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
     {
         var supplierId = Guid.NewGuid();
         _factory.SupplierServiceClientMock
-            .Setup(client => client.ValidateSupplierExistsAsync(
+            .Setup(client => client.GetSupplierAsync(
                 supplierId,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+            .ReturnsAsync((SupplierReference?)null);
         var request = new CreateMaterialRequest
         {
             Name = "Unknown supplier material",
@@ -187,7 +187,7 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
             var response = await _client.PostAsJsonAsync("/material/v1/materials", request);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            _factory.SupplierServiceClientMock.Verify(client => client.ValidateSupplierExistsAsync(
+            _factory.SupplierServiceClientMock.Verify(client => client.GetSupplierAsync(
                 supplierId,
                 It.IsAny<CancellationToken>()), Times.Once);
 
@@ -197,10 +197,10 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
         finally
         {
             _factory.SupplierServiceClientMock
-                .Setup(client => client.ValidateSupplierExistsAsync(
+                .Setup(client => client.GetSupplierAsync(
                     supplierId,
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
+                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier"));
         }
     }
 
@@ -212,10 +212,10 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
         var originalSupplierId = material.SupplierId;
         var supplierId = Guid.NewGuid();
         _factory.SupplierServiceClientMock
-            .Setup(client => client.ValidateSupplierExistsAsync(
+            .Setup(client => client.GetSupplierAsync(
                 supplierId,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+            .ReturnsAsync((SupplierReference?)null);
         var request = new UpdateMaterialRequest
         {
             Name = material.Name,
@@ -231,7 +231,7 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
             var response = await _client.PutAsJsonAsync($"/material/v1/materials/{material.Id}", request);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            _factory.SupplierServiceClientMock.Verify(client => client.ValidateSupplierExistsAsync(
+            _factory.SupplierServiceClientMock.Verify(client => client.GetSupplierAsync(
                 supplierId,
                 It.IsAny<CancellationToken>()), Times.Once);
 
@@ -242,11 +242,114 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
         finally
         {
             _factory.SupplierServiceClientMock
-                .Setup(client => client.ValidateSupplierExistsAsync(
+                .Setup(client => client.GetSupplierAsync(
                     supplierId,
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
+                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier"));
         }
+    }
+
+    [Fact]
+    public async Task CreateMaterial_WithAuthoritativeSupplier_PersistsLocalProjection()
+    {
+        var supplierId = Guid.NewGuid();
+        const string companyName = "Remote Supplier One";
+        _factory.SupplierServiceClientMock
+            .Setup(client => client.GetSupplierAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SupplierReference(supplierId, companyName));
+        var request = new CreateMaterialRequest
+        {
+            Name = "Projected supplier material",
+            Code = $"PROJ-{Guid.NewGuid():N}",
+            StockLevel = 2,
+            PricePerUnit = 20m,
+            SupplierId = supplierId
+        };
+
+        var response = await _client.PostAsJsonAsync("/material/v1/materials", request);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var dbContext = _scope.ServiceProvider.GetRequiredService<MaterialDbContext>();
+        dbContext.ChangeTracker.Clear();
+        var persisted = await dbContext.Materials
+            .AsNoTracking()
+            .Include(material => material.Supplier)
+            .SingleAsync(material => material.Code == request.Code);
+        Assert.Equal(supplierId, persisted.SupplierId);
+        Assert.NotNull(persisted.Supplier);
+        Assert.Equal(companyName, persisted.Supplier.Name);
+    }
+
+    [Fact]
+    public async Task UpdateMaterial_WithAuthoritativeSupplier_PersistsLocalProjection()
+    {
+        var dbContext = _scope.ServiceProvider.GetRequiredService<MaterialDbContext>();
+        var material = await dbContext.Materials.AsNoTracking().FirstAsync();
+        var supplierId = Guid.NewGuid();
+        const string companyName = "Remote Supplier Two";
+        _factory.SupplierServiceClientMock
+            .Setup(client => client.GetSupplierAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SupplierReference(supplierId, companyName));
+        var request = new UpdateMaterialRequest
+        {
+            Name = material.Name,
+            Code = material.Code,
+            Description = material.Description,
+            StockLevel = material.StockLevel,
+            PricePerUnit = material.PricePerUnit,
+            SupplierId = supplierId
+        };
+
+        var response = await _client.PutAsJsonAsync($"/material/v1/materials/{material.Id}", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        dbContext.ChangeTracker.Clear();
+        var persisted = await dbContext.Materials
+            .AsNoTracking()
+            .Include(item => item.Supplier)
+            .SingleAsync(item => item.Id == material.Id);
+        Assert.Equal(supplierId, persisted.SupplierId);
+        Assert.NotNull(persisted.Supplier);
+        Assert.Equal(companyName, persisted.Supplier.Name);
+    }
+
+    [Fact]
+    public async Task UpdateMaterial_WhenSupplierDependencyFails_ReturnsUnavailableWithoutMutation()
+    {
+        var dbContext = _scope.ServiceProvider.GetRequiredService<MaterialDbContext>();
+        var material = await dbContext.Materials.AsNoTracking().FirstAsync();
+        var originalName = material.Name;
+        var originalSupplierId = material.SupplierId;
+        var supplierId = Guid.NewGuid();
+        _factory.SupplierServiceClientMock
+            .Setup(client => client.GetSupplierAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException(
+                "Supplier unavailable",
+                inner: null,
+                HttpStatusCode.ServiceUnavailable));
+        var request = new UpdateMaterialRequest
+        {
+            Name = "Must not persist",
+            Code = material.Code,
+            Description = material.Description,
+            StockLevel = material.StockLevel,
+            PricePerUnit = material.PricePerUnit,
+            SupplierId = supplierId
+        };
+
+        var response = await _client.PutAsJsonAsync($"/material/v1/materials/{material.Id}", request);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        dbContext.ChangeTracker.Clear();
+        var persisted = await dbContext.Materials.AsNoTracking().SingleAsync(item => item.Id == material.Id);
+        Assert.Equal(originalName, persisted.Name);
+        Assert.Equal(originalSupplierId, persisted.SupplierId);
     }
 
     [Fact]

--- a/Maliev.MaterialService.Tests/Integration/MaterialsControllerTests.cs
+++ b/Maliev.MaterialService.Tests/Integration/MaterialsControllerTests.cs
@@ -9,11 +9,13 @@ using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Maliev.MaterialService.Application.DTOs;
 using Maliev.MaterialService.Application.DTOs.Materials;
+using Maliev.MaterialService.Application.Services;
 using Maliev.MaterialService.Infrastructure.Persistence;
 using Maliev.MaterialService.Tests.Fixtures;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Maliev.MaterialService.Tests.Integration;
@@ -160,6 +162,91 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateMaterial_WithUnknownSupplier_ReturnsBadRequestBeforePersistence()
+    {
+        var supplierId = Guid.NewGuid();
+        _factory.SupplierServiceClientMock
+            .Setup(client => client.ValidateSupplierExistsAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var request = new CreateMaterialRequest
+        {
+            Name = "Unknown supplier material",
+            Code = $"UNKNOWN-SUPPLIER-{Guid.NewGuid():N}",
+            StockLevel = 1,
+            PricePerUnit = 10m,
+            SupplierId = supplierId
+        };
+
+        try
+        {
+            var response = await _client.PostAsJsonAsync("/material/v1/materials", request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            _factory.SupplierServiceClientMock.Verify(client => client.ValidateSupplierExistsAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            var dbContext = _scope.ServiceProvider.GetRequiredService<MaterialDbContext>();
+            Assert.False(await dbContext.Materials.AnyAsync(material => material.Code == request.Code));
+        }
+        finally
+        {
+            _factory.SupplierServiceClientMock
+                .Setup(client => client.ValidateSupplierExistsAsync(
+                    supplierId,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateMaterial_WithUnknownSupplier_ReturnsBadRequestBeforeMutation()
+    {
+        var dbContext = _scope.ServiceProvider.GetRequiredService<MaterialDbContext>();
+        var material = await dbContext.Materials.AsNoTracking().FirstAsync();
+        var originalSupplierId = material.SupplierId;
+        var supplierId = Guid.NewGuid();
+        _factory.SupplierServiceClientMock
+            .Setup(client => client.ValidateSupplierExistsAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var request = new UpdateMaterialRequest
+        {
+            Name = material.Name,
+            Code = material.Code,
+            Description = material.Description,
+            StockLevel = material.StockLevel,
+            PricePerUnit = material.PricePerUnit,
+            SupplierId = supplierId
+        };
+
+        try
+        {
+            var response = await _client.PutAsJsonAsync($"/material/v1/materials/{material.Id}", request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            _factory.SupplierServiceClientMock.Verify(client => client.ValidateSupplierExistsAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            dbContext.ChangeTracker.Clear();
+            var persisted = await dbContext.Materials.AsNoTracking().SingleAsync(item => item.Id == material.Id);
+            Assert.Equal(originalSupplierId, persisted.SupplierId);
+        }
+        finally
+        {
+            _factory.SupplierServiceClientMock
+                .Setup(client => client.ValidateSupplierExistsAsync(
+                    supplierId,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+        }
     }
 
     [Fact]

--- a/Maliev.MaterialService.Tests/Maliev.MaterialService.Tests.csproj
+++ b/Maliev.MaterialService.Tests/Maliev.MaterialService.Tests.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.MaterialService.Tests/Testing/BaseIntegrationTestFactory.cs
+++ b/Maliev.MaterialService.Tests/Testing/BaseIntegrationTestFactory.cs
@@ -4,6 +4,7 @@ using MassTransit;
 using Microsoft.Extensions.Configuration;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -169,6 +170,15 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
             {
                 ["Service:Name"] = "MaterialService",
                 ["Service:Version"] = "1.0.0-test",
+                ["ServiceAuthentication:ClientId"] = "service-material-service",
+                ["ServiceAuthentication:ClientSecret"] = "material-integration-secret-with-at-least-32-bytes",
+                ["Services:AuthService:BaseUrl"] = "https://auth.test",
+                ["Services:IAMService:BaseUrl"] = "https://iam.test",
+                ["Services:SupplierService:BaseUrl"] = "https://supplier.test",
+                ["Jwt:PublicKey"] = Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes(_testRsa.ExportSubjectPublicKeyInfoPem())),
+                ["Jwt:Issuer"] = "https://issuer.test",
+                ["Jwt:Audience"] = "https://audience.test",
                 ["Jwt:SecurityKey"] = "test-secret-key-at-least-32-characters-long",
                 [$"ConnectionStrings:{DbConnectionStringName}"] = _postgresContainer!.GetConnectionString(),
                 ["ConnectionStrings:redis"] = _redisContainer!.GetConnectionString(),

--- a/Maliev.MaterialService.Tests/Unit/ServiceAuthenticationWiringTests.cs
+++ b/Maliev.MaterialService.Tests/Unit/ServiceAuthenticationWiringTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using Maliev.Aspire.ServiceDefaults;
+using Maliev.Aspire.ServiceDefaults.Authorization;
+using Maliev.Aspire.ServiceDefaults.IAM;
+using Maliev.MaterialService.Application.Services;
+using Maliev.MaterialService.Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+
+namespace Maliev.MaterialService.Tests.Unit;
+
+/// <summary>
+/// Verifies MaterialService's centrally issued workload-authentication boundary.
+/// </summary>
+public sealed class ServiceAuthenticationWiringTests
+{
+    private const string ExpectedToken = "centrally-issued-material-token";
+
+    /// <summary>
+    /// Startup must opt into AuthService exchange and remove the legacy local signer.
+    /// </summary>
+    [Fact]
+    public void Program_RegistersMaterialExchangeWithoutLegacySigner()
+    {
+        var source = ReadRepositoryFile("Maliev.MaterialService.Api", "Program.cs");
+
+        Assert.Contains("builder.AddAuthServiceTokenExchange(\"MaterialService\");", source, StringComparison.Ordinal);
+        Assert.Contains("builder.AddAuthServiceIAMClient();", source, StringComparison.Ordinal);
+        Assert.Contains(".AddAuthServiceAuthentication()", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddIAMServiceClient", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddAuthenticatedServiceClient", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The protected Supplier client must use the AuthService-issued bearer token.
+    /// </summary>
+    [Fact]
+    public async Task SupplierClient_UsesAuthServiceBearer()
+    {
+        var builder = CreateConfiguredBuilder();
+        var filter = new TrackingPrimaryHandlerFilter();
+        builder.Services.AddSingleton<IHttpMessageHandlerBuilderFilter>(filter);
+
+        builder.AddAuthServiceTokenExchange("MaterialService");
+        builder.Services.AddSingleton<IAuthServiceTokenProvider>(new StubTokenProvider());
+        builder.Services.AddHttpClient<ISupplierServiceClient, SupplierServiceClient>("SupplierService", client =>
+            {
+                client.BaseAddress = new Uri("https://supplier.test");
+            })
+            .AddAuthServiceAuthentication();
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        using var client = factory.CreateClient("SupplierService");
+        using var response = await client.GetAsync("/probe", CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(
+            new AuthenticationHeaderValue("Bearer", ExpectedToken),
+            filter.GetCapture("SupplierService").Authorization);
+        Assert.True(filter.HasAuthServiceHandler("SupplierService"));
+    }
+
+    /// <summary>
+    /// Material uses its exact process identity and does not resolve legacy signing services.
+    /// </summary>
+    [Fact]
+    public void MaterialExchange_RegistersExactIdentityWithoutLegacySigningServices()
+    {
+        var builder = CreateConfiguredBuilder();
+        builder.AddAuthServiceTokenExchange("MaterialService");
+        builder.AddAuthServiceIAMClient();
+
+        using var provider = builder.Services.BuildServiceProvider();
+
+        Assert.Equal("MaterialService", provider.GetRequiredService<ServiceProcessIdentity>().ServiceName);
+        Assert.Null(provider.GetService<IServiceAccountTokenProvider>());
+        Assert.Null(provider.GetService<ServiceAccountAuthenticationHandler>());
+    }
+
+    /// <summary>
+    /// Invalid workload credentials must stop the host rather than permit anonymous fallback.
+    /// </summary>
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("service-material-service", "short")]
+    public async Task AuthServiceExchange_InvalidCredentials_FailsClosedAtHostStartup(
+        string? clientId,
+        string? clientSecret)
+    {
+        var builder = CreateConfiguredBuilder(clientId, clientSecret);
+        builder.AddAuthServiceTokenExchange("MaterialService");
+
+        using var host = builder.Build();
+
+        await Assert.ThrowsAsync<OptionsValidationException>(() => host.StartAsync());
+    }
+
+    /// <summary>
+    /// CI must restore the ServiceDefaults release that owns central exchange behavior.
+    /// </summary>
+    [Fact]
+    public void ServiceDefaultsDependency_PinsPublishedCentralExchangeVersion()
+    {
+        var source = ReadRepositoryFile("Directory.Build.props");
+
+        Assert.Contains(
+            "<ServiceDefaultsVersion Condition=\"'$(ServiceDefaultsVersion)' == ''\">1.0.89-alpha</ServiceDefaultsVersion>",
+            source,
+            StringComparison.Ordinal);
+
+        foreach (var project in new[]
+                 {
+                     "Maliev.MaterialService.Api/Maliev.MaterialService.Api.csproj",
+                     "Maliev.MaterialService.Application/Maliev.MaterialService.Application.csproj",
+                     "Maliev.MaterialService.Infrastructure/Maliev.MaterialService.Infrastructure.csproj",
+                     "Maliev.MaterialService.Tests/Maliev.MaterialService.Tests.csproj"
+                 })
+        {
+            var projectSource = ReadRepositoryFile(project.Split('/'));
+            Assert.Contains(
+                "<PackageReference Include=\"Maliev.Aspire.ServiceDefaults\" Version=\"$(ServiceDefaultsVersion)\" />",
+                projectSource,
+                StringComparison.Ordinal);
+        }
+    }
+
+    private static HostApplicationBuilder CreateConfiguredBuilder(
+        string? clientId = "service-material-service",
+        string? clientSecret = "material-test-secret-with-at-least-32-bytes")
+    {
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = "Testing"
+        });
+
+        using var rsa = RSA.Create(2048);
+        builder.Configuration["ServiceAuthentication:ClientId"] = clientId;
+        builder.Configuration["ServiceAuthentication:ClientSecret"] = clientSecret;
+        builder.Configuration["Services:AuthService:BaseUrl"] = "https://auth.test";
+        builder.Configuration["Services:IAMService:BaseUrl"] = "https://iam.test";
+        builder.Configuration["Jwt:PublicKey"] = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes(rsa.ExportSubjectPublicKeyInfoPem()));
+        builder.Configuration["Jwt:Issuer"] = "https://api.maliev.com";
+        builder.Configuration["Jwt:Audience"] = "https://api.maliev.com";
+
+        return builder;
+    }
+
+    private static string ReadRepositoryFile(params string[] segments)
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            Path.Combine(segments)));
+
+        Assert.True(File.Exists(path), $"Could not find source file: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private sealed class StubTokenProvider : IAuthServiceTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(ExpectedToken);
+    }
+
+    private sealed class AuthorizationCaptureHandler : HttpMessageHandler
+    {
+        public AuthenticationHeaderValue? Authorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Authorization = request.Headers.Authorization;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private sealed class TrackingPrimaryHandlerFilter : IHttpMessageHandlerBuilderFilter
+    {
+        private readonly Dictionary<string, AuthorizationCaptureHandler> _captures = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, bool> _authHandlers = new(StringComparer.Ordinal);
+
+        public AuthorizationCaptureHandler GetCapture(string clientName) => _captures[clientName];
+
+        public bool HasAuthServiceHandler(string clientName) => _authHandlers[clientName];
+
+        public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next) => builder =>
+        {
+            next(builder);
+            var clientName = builder.Name
+                ?? throw new InvalidOperationException("Every HttpClientFactory handler must have a client name.");
+            _authHandlers[clientName] = builder.AdditionalHandlers.Any(
+                handler => handler is AuthServiceTokenExchangeHandler);
+
+            for (var index = builder.AdditionalHandlers.Count - 1; index >= 0; index--)
+            {
+                if (builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ServiceDiscovery",
+                        StringComparison.Ordinal) == true ||
+                    builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ResolvingHttpDelegatingHandler",
+                        StringComparison.Ordinal) == true)
+                {
+                    builder.AdditionalHandlers.RemoveAt(index);
+                }
+            }
+
+            var capture = new AuthorizationCaptureHandler();
+            _captures[clientName] = capture;
+            builder.PrimaryHandler = capture;
+        };
+    }
+}

--- a/Maliev.MaterialService.Tests/Unit/Services/BulkMaterialServiceTests.cs
+++ b/Maliev.MaterialService.Tests/Unit/Services/BulkMaterialServiceTests.cs
@@ -38,14 +38,21 @@ public class BulkMaterialServiceTests
             }
         };
 
-        _materialServiceMock.Setup(s => s.CreateMaterialAsync(It.IsAny<CreateMaterialRequest>(), It.IsAny<string>()))
-            .ReturnsAsync((CreateMaterialRequest r, string u) => new MaterialResponse { Name = r.Name, Code = r.Code });
+        _materialServiceMock.Setup(s => s.CreateMaterialAsync(
+                It.IsAny<CreateMaterialRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CreateMaterialRequest r, string u, CancellationToken ct) =>
+                new MaterialResponse { Name = r.Name, Code = r.Code });
 
         var result = await _bulkService.BulkImportMaterialsAsync(request, "TestUser");
 
         Assert.Equal(2, result.SuccessCount);
         Assert.Equal(0, result.FailureCount);
-        _materialServiceMock.Verify(s => s.CreateMaterialAsync(It.IsAny<CreateMaterialRequest>(), "TestUser"), Times.Exactly(2));
+        _materialServiceMock.Verify(s => s.CreateMaterialAsync(
+            It.IsAny<CreateMaterialRequest>(),
+            "TestUser",
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -60,10 +67,16 @@ public class BulkMaterialServiceTests
             }
         };
 
-        _materialServiceMock.Setup(s => s.CreateMaterialAsync(It.Is<CreateMaterialRequest>(r => r.Code == "C1"), It.IsAny<string>()))
+        _materialServiceMock.Setup(s => s.CreateMaterialAsync(
+                It.Is<CreateMaterialRequest>(r => r.Code == "C1"),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MaterialResponse { Name = "Mat1", Code = "C1" });
 
-        _materialServiceMock.Setup(s => s.CreateMaterialAsync(It.Is<CreateMaterialRequest>(r => r.Code == "C2"), It.IsAny<string>()))
+        _materialServiceMock.Setup(s => s.CreateMaterialAsync(
+                It.Is<CreateMaterialRequest>(r => r.Code == "C2"),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Duplicate code"));
 
         var result = await _bulkService.BulkImportMaterialsAsync(request, "TestUser");
@@ -90,7 +103,10 @@ public class BulkMaterialServiceTests
 
         Assert.Equal(1, result.SuccessCount);
         Assert.Equal(0, result.FailureCount);
-        _materialServiceMock.Verify(s => s.CreateMaterialAsync(It.IsAny<CreateMaterialRequest>(), It.IsAny<string>()), Times.Never);
+        _materialServiceMock.Verify(s => s.CreateMaterialAsync(
+            It.IsAny<CreateMaterialRequest>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -109,7 +125,10 @@ public class BulkMaterialServiceTests
 
         Assert.Equal(1, result.SuccessCount);
         Assert.Equal(0, result.FailureCount);
-        _materialServiceMock.Verify(s => s.CreateMaterialAsync(It.IsAny<CreateMaterialRequest>(), It.IsAny<string>()), Times.Never);
+        _materialServiceMock.Verify(s => s.CreateMaterialAsync(
+            It.IsAny<CreateMaterialRequest>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -139,7 +158,10 @@ public class BulkMaterialServiceTests
             }
         };
 
-        _materialServiceMock.Setup(s => s.CreateMaterialAsync(It.IsAny<CreateMaterialRequest>(), It.IsAny<string>()))
+        _materialServiceMock.Setup(s => s.CreateMaterialAsync(
+                It.IsAny<CreateMaterialRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Validation failed"));
 
         var result = await _bulkService.BulkImportMaterialsAsync(request, "TestUser");

--- a/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
+++ b/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
@@ -60,6 +60,22 @@ public sealed class SupplierServiceClientTests
     }
 
     /// <summary>
+    /// A successful response with an unreadable projection is a dependency failure, not an internal error.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("{not-json")]
+    public async Task GetSupplierAsync_MalformedSuccess_ThrowsBadGateway(string body)
+    {
+        var client = CreateClient(new CapturingHandler(HttpStatusCode.OK, body));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetSupplierAsync(Guid.NewGuid(), CancellationToken.None));
+
+        Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
+    }
+
+    /// <summary>
     /// Caller cancellation must reach the outbound Supplier request.
     /// </summary>
     [Fact]

--- a/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
+++ b/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using Maliev.MaterialService.Infrastructure.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Maliev.MaterialService.Tests.Unit.Services;
+
+/// <summary>
+/// Verifies the protected SupplierService lookup contract.
+/// </summary>
+public sealed class SupplierServiceClientTests
+{
+    /// <summary>
+    /// A successful supplier lookup uses the versioned protected route.
+    /// </summary>
+    [Fact]
+    public async Task ValidateSupplierExistsAsync_Success_UsesVersionedRoute()
+    {
+        var supplierId = Guid.NewGuid();
+        var handler = new CapturingHandler(HttpStatusCode.OK);
+        var client = CreateClient(handler);
+
+        var exists = await client.ValidateSupplierExistsAsync(supplierId, CancellationToken.None);
+
+        Assert.True(exists);
+        Assert.Equal($"/supplier/v1/suppliers/{supplierId}", handler.RequestUri?.AbsolutePath);
+    }
+
+    /// <summary>
+    /// Only an authoritative 404 is translated into a missing supplier result.
+    /// </summary>
+    [Fact]
+    public async Task ValidateSupplierExistsAsync_NotFound_ReturnsFalse()
+    {
+        var client = CreateClient(new CapturingHandler(HttpStatusCode.NotFound));
+
+        var exists = await client.ValidateSupplierExistsAsync(Guid.NewGuid(), CancellationToken.None);
+
+        Assert.False(exists);
+    }
+
+    /// <summary>
+    /// Authorization and dependency failures must not masquerade as missing suppliers.
+    /// </summary>
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task ValidateSupplierExistsAsync_DependencyFailure_Throws(HttpStatusCode statusCode)
+    {
+        var client = CreateClient(new CapturingHandler(statusCode));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.ValidateSupplierExistsAsync(Guid.NewGuid(), CancellationToken.None));
+
+        Assert.Equal(statusCode, exception.StatusCode);
+    }
+
+    /// <summary>
+    /// Caller cancellation must reach the outbound Supplier request.
+    /// </summary>
+    [Fact]
+    public async Task ValidateSupplierExistsAsync_Cancelled_PropagatesCancellation()
+    {
+        var handler = new CancellationAwareHandler();
+        var client = CreateClient(handler);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.ValidateSupplierExistsAsync(Guid.NewGuid(), cancellation.Token));
+
+        Assert.True(handler.ObservedCancellation);
+    }
+
+    private static SupplierServiceClient CreateClient(HttpMessageHandler handler) =>
+        new(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://supplier.test")
+            },
+            NullLogger<SupplierServiceClient>.Instance);
+
+    private sealed class CapturingHandler(HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        public Uri? RequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(statusCode));
+        }
+    }
+
+    private sealed class CancellationAwareHandler : HttpMessageHandler
+    {
+        public bool ObservedCancellation { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            ObservedCancellation = cancellationToken.IsCancellationRequested;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
+++ b/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
@@ -13,29 +13,33 @@ public sealed class SupplierServiceClientTests
     /// A successful supplier lookup uses the versioned protected route.
     /// </summary>
     [Fact]
-    public async Task ValidateSupplierExistsAsync_Success_UsesVersionedRoute()
+    public async Task GetSupplierAsync_Success_UsesVersionedValidationRoute()
     {
         var supplierId = Guid.NewGuid();
-        var handler = new CapturingHandler(HttpStatusCode.OK);
+        var handler = new CapturingHandler(
+            HttpStatusCode.OK,
+            $$"""{"id":"{{supplierId}}","companyName":"Supplier One","isActive":true}""");
         var client = CreateClient(handler);
 
-        var exists = await client.ValidateSupplierExistsAsync(supplierId, CancellationToken.None);
+        var supplier = await client.GetSupplierAsync(supplierId, CancellationToken.None);
 
-        Assert.True(exists);
-        Assert.Equal($"/supplier/v1/suppliers/{supplierId}", handler.RequestUri?.AbsolutePath);
+        Assert.NotNull(supplier);
+        Assert.Equal(supplierId, supplier.Id);
+        Assert.Equal("Supplier One", supplier.CompanyName);
+        Assert.Equal($"/supplier/v1/suppliers/{supplierId}/validate", handler.RequestUri?.AbsolutePath);
     }
 
     /// <summary>
     /// Only an authoritative 404 is translated into a missing supplier result.
     /// </summary>
     [Fact]
-    public async Task ValidateSupplierExistsAsync_NotFound_ReturnsFalse()
+    public async Task GetSupplierAsync_NotFound_ReturnsNull()
     {
         var client = CreateClient(new CapturingHandler(HttpStatusCode.NotFound));
 
-        var exists = await client.ValidateSupplierExistsAsync(Guid.NewGuid(), CancellationToken.None);
+        var supplier = await client.GetSupplierAsync(Guid.NewGuid(), CancellationToken.None);
 
-        Assert.False(exists);
+        Assert.Null(supplier);
     }
 
     /// <summary>
@@ -45,12 +49,12 @@ public sealed class SupplierServiceClientTests
     [InlineData(HttpStatusCode.Unauthorized)]
     [InlineData(HttpStatusCode.Forbidden)]
     [InlineData(HttpStatusCode.ServiceUnavailable)]
-    public async Task ValidateSupplierExistsAsync_DependencyFailure_Throws(HttpStatusCode statusCode)
+    public async Task GetSupplierAsync_DependencyFailure_Throws(HttpStatusCode statusCode)
     {
         var client = CreateClient(new CapturingHandler(statusCode));
 
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.ValidateSupplierExistsAsync(Guid.NewGuid(), CancellationToken.None));
+            () => client.GetSupplierAsync(Guid.NewGuid(), CancellationToken.None));
 
         Assert.Equal(statusCode, exception.StatusCode);
     }
@@ -59,7 +63,7 @@ public sealed class SupplierServiceClientTests
     /// Caller cancellation must reach the outbound Supplier request.
     /// </summary>
     [Fact]
-    public async Task ValidateSupplierExistsAsync_Cancelled_PropagatesCancellation()
+    public async Task GetSupplierAsync_Cancelled_PropagatesCancellation()
     {
         var handler = new CancellationAwareHandler();
         var client = CreateClient(handler);
@@ -67,7 +71,7 @@ public sealed class SupplierServiceClientTests
         cancellation.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => client.ValidateSupplierExistsAsync(Guid.NewGuid(), cancellation.Token));
+            () => client.GetSupplierAsync(Guid.NewGuid(), cancellation.Token));
 
         Assert.True(handler.ObservedCancellation);
     }
@@ -80,7 +84,7 @@ public sealed class SupplierServiceClientTests
             },
             NullLogger<SupplierServiceClient>.Instance);
 
-    private sealed class CapturingHandler(HttpStatusCode statusCode) : HttpMessageHandler
+    private sealed class CapturingHandler(HttpStatusCode statusCode, string? body = null) : HttpMessageHandler
     {
         public Uri? RequestUri { get; private set; }
 
@@ -89,7 +93,10 @@ public sealed class SupplierServiceClientTests
             CancellationToken cancellationToken)
         {
             RequestUri = request.RequestUri;
-            return Task.FromResult(new HttpResponseMessage(statusCode));
+            return Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                Content = body is null ? null : new StringContent(body)
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- replace legacy local IAM token signing with AuthService workload-token exchange
- authenticate the central IAM and SupplierService clients with the MaterialService identity
- validate Supplier IDs on create/update using the protected versioned Supplier v1 route and persist a minimal local FK projection
- propagate cancellation, keep resilient calls outside DB transactions, distinguish authoritative 404 from dependency failures, and return 503 without mutation
- pin the ServiceDefaults release that owns the central exchange contract

## Validation
- `dotnet format Maliev.MaterialService.slnx --verify-no-changes`
- Release build: 0 warnings, 0 errors
- full Release tests: 114/114
- real PostgreSQL/Redis/RabbitMQ integration tests prove create/update reject an unknown Supplier before mutation
- 12 focused central-auth and Supplier client tests

## Safety
- no application or Argo manifest enabled
- no credential or signing key committed
- generated image/GitOps evidence must remain draft `[DO NOT MERGE]`

Tracks MALIEV-Co-Ltd/maliev-ops#97
