### PR TITLE
fix(material): use minimal supplier reference endpoint

### DIFF
--- a/Maliev.MaterialService.Application/Services/ISupplierServiceClient.cs
+++ b/Maliev.MaterialService.Application/Services/ISupplierServiceClient.cs
@@ -6,11 +6,11 @@ namespace Maliev.MaterialService.Application.Services;
 public interface ISupplierServiceClient
 {
     /// <summary>
-    /// Gets the authoritative active Supplier projection required by MaterialService.
+    /// Gets the authoritative Supplier projection required by MaterialService.
     /// </summary>
     /// <param name="supplierId">The supplier ID to validate.</param>
     /// <param name="cancellationToken">Cancellation token for the outbound request.</param>
-    /// <returns>The active supplier projection, or null when SupplierService returns not found.</returns>
+    /// <returns>The supplier projection, or null when SupplierService returns not found.</returns>
     Task<SupplierReference?> GetSupplierAsync(
         Guid supplierId,
         CancellationToken cancellationToken = default);
@@ -21,4 +21,5 @@ public interface ISupplierServiceClient
 /// </summary>
 /// <param name="Id">Supplier identifier.</param>
 /// <param name="CompanyName">Current supplier company name.</param>
-public sealed record SupplierReference(Guid Id, string CompanyName);
+/// <param name="IsActive">Whether the authoritative supplier is active.</param>
+public sealed record SupplierReference(Guid Id, string CompanyName, bool IsActive);

--- a/Maliev.MaterialService.Infrastructure/Services/MaterialService.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/MaterialService.cs
@@ -528,6 +528,10 @@ public class MaterialService : IMaterialService
         {
             throw new InvalidOperationException($"Supplier with ID '{supplierId.Value}' does not exist.");
         }
+        if (!supplier.IsActive)
+        {
+            throw new InvalidOperationException($"Supplier with ID '{supplierId.Value}' is not active.");
+        }
 
         return supplier;
     }

--- a/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
@@ -31,7 +31,7 @@ public class SupplierServiceClient : ISupplierServiceClient
         CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync(
-            $"/supplier/v1/suppliers/{supplierId}/validate",
+            $"/supplier/v1/suppliers/{supplierId}/reference",
             cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.NotFound)

--- a/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
+++ b/Maliev.MaterialService.Infrastructure/Services/SupplierServiceClient.cs
@@ -40,10 +40,10 @@ public class SupplierServiceClient : ISupplierServiceClient
         }
 
         response.EnsureSuccessStatusCode();
-        SupplierValidationResponse? supplier;
+        SupplierReferenceWireResponse? supplier;
         try
         {
-            supplier = await response.Content.ReadFromJsonAsync<SupplierValidationResponse>(
+            supplier = await response.Content.ReadFromJsonAsync<SupplierReferenceWireResponse>(
                 cancellationToken);
         }
         catch (Exception exception) when (exception is JsonException or NotSupportedException)
@@ -60,7 +60,7 @@ public class SupplierServiceClient : ISupplierServiceClient
         if (supplier is null ||
             supplier.Id != supplierId ||
             string.IsNullOrWhiteSpace(supplier.CompanyName) ||
-            !supplier.IsActive)
+            !supplier.IsActive.HasValue)
         {
             _logger.LogError(
                 "Supplier Service returned an invalid projection for {SupplierId}",
@@ -71,11 +71,11 @@ public class SupplierServiceClient : ISupplierServiceClient
                 HttpStatusCode.BadGateway);
         }
 
-        return new SupplierReference(supplier.Id, supplier.CompanyName);
+        return new SupplierReference(supplier.Id, supplier.CompanyName, supplier.IsActive.Value);
     }
 
-    private sealed record SupplierValidationResponse(
+    private sealed record SupplierReferenceWireResponse(
         Guid Id,
         string CompanyName,
-        bool IsActive);
+        bool? IsActive);
 }

--- a/Maliev.MaterialService.Tests/Fixtures/IntegrationTestWebAppFactory.cs
+++ b/Maliev.MaterialService.Tests/Fixtures/IntegrationTestWebAppFactory.cs
@@ -65,7 +65,7 @@ public class IntegrationTestWebAppFactory : BaseIntegrationTestFactory<Program, 
                 It.IsAny<Guid>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid supplierId, CancellationToken _) =>
-                new SupplierReference(supplierId, $"Supplier {supplierId:N}"));
+                new SupplierReference(supplierId, $"Supplier {supplierId:N}", IsActive: true));
         return mock;
     }
 }

--- a/Maliev.MaterialService.Tests/Integration/MaterialsControllerTests.cs
+++ b/Maliev.MaterialService.Tests/Integration/MaterialsControllerTests.cs
@@ -200,7 +200,44 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
                 .Setup(client => client.GetSupplierAsync(
                     supplierId,
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier"));
+                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier", IsActive: true));
+        }
+    }
+
+    [Fact]
+    public async Task CreateMaterial_WithInactiveSupplier_ReturnsBadRequestBeforePersistence()
+    {
+        var supplierId = Guid.NewGuid();
+        _factory.SupplierServiceClientMock
+            .Setup(client => client.GetSupplierAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SupplierReference(supplierId, "Inactive Supplier", IsActive: false));
+        var request = new CreateMaterialRequest
+        {
+            Name = "Inactive supplier material",
+            Code = $"INACTIVE-SUPPLIER-{Guid.NewGuid():N}",
+            StockLevel = 1,
+            PricePerUnit = 10m,
+            SupplierId = supplierId
+        };
+
+        try
+        {
+            var response = await _client.PostAsJsonAsync("/material/v1/materials", request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var dbContext = _scope.ServiceProvider.GetRequiredService<MaterialDbContext>();
+            Assert.False(await dbContext.Materials.AnyAsync(material => material.Code == request.Code));
+            Assert.False(await dbContext.Suppliers.AnyAsync(supplier => supplier.Id == supplierId));
+        }
+        finally
+        {
+            _factory.SupplierServiceClientMock
+                .Setup(client => client.GetSupplierAsync(
+                    supplierId,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier", IsActive: true));
         }
     }
 
@@ -245,7 +282,51 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
                 .Setup(client => client.GetSupplierAsync(
                     supplierId,
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier"));
+                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier", IsActive: true));
+        }
+    }
+
+    [Fact]
+    public async Task UpdateMaterial_WithInactiveSupplier_ReturnsBadRequestBeforeMutation()
+    {
+        var dbContext = _scope.ServiceProvider.GetRequiredService<MaterialDbContext>();
+        var material = await dbContext.Materials.AsNoTracking().FirstAsync();
+        var originalName = material.Name;
+        var originalSupplierId = material.SupplierId;
+        var supplierId = Guid.NewGuid();
+        _factory.SupplierServiceClientMock
+            .Setup(client => client.GetSupplierAsync(
+                supplierId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SupplierReference(supplierId, "Inactive Supplier", IsActive: false));
+        var request = new UpdateMaterialRequest
+        {
+            Name = "Must not persist inactive supplier",
+            Code = material.Code,
+            Description = material.Description,
+            StockLevel = material.StockLevel,
+            PricePerUnit = material.PricePerUnit,
+            SupplierId = supplierId
+        };
+
+        try
+        {
+            var response = await _client.PutAsJsonAsync($"/material/v1/materials/{material.Id}", request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            dbContext.ChangeTracker.Clear();
+            var persisted = await dbContext.Materials.AsNoTracking().SingleAsync(item => item.Id == material.Id);
+            Assert.Equal(originalName, persisted.Name);
+            Assert.Equal(originalSupplierId, persisted.SupplierId);
+            Assert.False(await dbContext.Suppliers.AnyAsync(supplier => supplier.Id == supplierId));
+        }
+        finally
+        {
+            _factory.SupplierServiceClientMock
+                .Setup(client => client.GetSupplierAsync(
+                    supplierId,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SupplierReference(supplierId, "Recovered Supplier", IsActive: true));
         }
     }
 
@@ -258,7 +339,7 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
             .Setup(client => client.GetSupplierAsync(
                 supplierId,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new SupplierReference(supplierId, companyName));
+            .ReturnsAsync(new SupplierReference(supplierId, companyName, IsActive: true));
         var request = new CreateMaterialRequest
         {
             Name = "Projected supplier material",
@@ -293,7 +374,7 @@ public class MaterialsControllerTests : IClassFixture<IntegrationTestWebAppFacto
             .Setup(client => client.GetSupplierAsync(
                 supplierId,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new SupplierReference(supplierId, companyName));
+            .ReturnsAsync(new SupplierReference(supplierId, companyName, IsActive: true));
         var request = new UpdateMaterialRequest
         {
             Name = material.Name,

--- a/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
+++ b/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
@@ -13,7 +13,7 @@ public sealed class SupplierServiceClientTests
     /// A successful supplier lookup uses the versioned protected route.
     /// </summary>
     [Fact]
-    public async Task GetSupplierAsync_Success_UsesVersionedValidationRoute()
+    public async Task GetSupplierAsync_Success_UsesVersionedReferenceRoute()
     {
         var supplierId = Guid.NewGuid();
         var handler = new CapturingHandler(
@@ -26,7 +26,7 @@ public sealed class SupplierServiceClientTests
         Assert.NotNull(supplier);
         Assert.Equal(supplierId, supplier.Id);
         Assert.Equal("Supplier One", supplier.CompanyName);
-        Assert.Equal($"/supplier/v1/suppliers/{supplierId}/validate", handler.RequestUri?.AbsolutePath);
+        Assert.Equal($"/supplier/v1/suppliers/{supplierId}/reference", handler.RequestUri?.AbsolutePath);
     }
 
     /// <summary>

--- a/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
+++ b/Maliev.MaterialService.Tests/Unit/Services/SupplierServiceClientTests.cs
@@ -26,6 +26,7 @@ public sealed class SupplierServiceClientTests
         Assert.NotNull(supplier);
         Assert.Equal(supplierId, supplier.Id);
         Assert.Equal("Supplier One", supplier.CompanyName);
+        Assert.True(supplier.IsActive);
         Assert.Equal($"/supplier/v1/suppliers/{supplierId}/reference", handler.RequestUri?.AbsolutePath);
     }
 
@@ -40,6 +41,25 @@ public sealed class SupplierServiceClientTests
         var supplier = await client.GetSupplierAsync(Guid.NewGuid(), CancellationToken.None);
 
         Assert.Null(supplier);
+    }
+
+    /// <summary>
+    /// Inactive suppliers are structurally valid dependency responses and remain business data.
+    /// </summary>
+    [Fact]
+    public async Task GetSupplierAsync_InactiveReference_ReturnsProjection()
+    {
+        var supplierId = Guid.NewGuid();
+        var client = CreateClient(new CapturingHandler(
+            HttpStatusCode.OK,
+            $$"""{"id":"{{supplierId}}","companyName":"Inactive Supplier","isActive":false}"""));
+
+        var supplier = await client.GetSupplierAsync(supplierId, CancellationToken.None);
+
+        Assert.NotNull(supplier);
+        Assert.Equal(supplierId, supplier.Id);
+        Assert.Equal("Inactive Supplier", supplier.CompanyName);
+        Assert.False(supplier.IsActive);
     }
 
     /// <summary>
@@ -71,6 +91,56 @@ public sealed class SupplierServiceClientTests
 
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
             () => client.GetSupplierAsync(Guid.NewGuid(), CancellationToken.None));
+
+        Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
+    }
+
+    /// <summary>
+    /// A projection for a different supplier cannot satisfy the requested reference.
+    /// </summary>
+    [Fact]
+    public async Task GetSupplierAsync_WrongSupplierId_ThrowsBadGateway()
+    {
+        var client = CreateClient(new CapturingHandler(
+            HttpStatusCode.OK,
+            $$"""{"id":"{{Guid.NewGuid()}}","companyName":"Wrong Supplier","isActive":true}"""));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetSupplierAsync(Guid.NewGuid(), CancellationToken.None));
+
+        Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
+    }
+
+    /// <summary>
+    /// SupplierService must provide a usable company name for the local projection.
+    /// </summary>
+    [Fact]
+    public async Task GetSupplierAsync_BlankCompanyName_ThrowsBadGateway()
+    {
+        var supplierId = Guid.NewGuid();
+        var client = CreateClient(new CapturingHandler(
+            HttpStatusCode.OK,
+            $$"""{"id":"{{supplierId}}","companyName":" ","isActive":true}"""));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetSupplierAsync(supplierId, CancellationToken.None));
+
+        Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
+    }
+
+    /// <summary>
+    /// The active-state field is required to distinguish malformed data from an inactive supplier.
+    /// </summary>
+    [Fact]
+    public async Task GetSupplierAsync_MissingIsActive_ThrowsBadGateway()
+    {
+        var supplierId = Guid.NewGuid();
+        var client = CreateClient(new CapturingHandler(
+            HttpStatusCode.OK,
+            $$"""{"id":"{{supplierId}}","companyName":"Missing State Supplier"}"""));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetSupplierAsync(supplierId, CancellationToken.None));
 
         Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
     }


### PR DESCRIPTION
## Summary
- consume the additive minimal SupplierService `/reference` endpoint
- retain `IsActive` as authoritative business data instead of classifying inactive suppliers as malformed
- reject inactive suppliers with HTTP 400 before supplier projection upsert or material create/update mutation
- preserve 404, 401/403/503, malformed/empty/missing-state/wrong-ID/blank-name, and cancellation behavior

## Dependencies
Merge order: SupplierService #21 → IAM Material profile → Aspire Material seed/live token → this PR.

## Validation
- Red: client route observed `/validate` instead of `/reference`
- Red: `SupplierReference` lacked active state
- Red: inactive supplier create returned 201 and update returned 200, mutating persistence
- Red: omitted `isActive` was indistinguishable from authoritative false
- focused client tests: 12/12
- focused client/business/dependency tests: 15/15
- full Release tests: 122/122
- Release build: 0 warnings, 0 errors
- format verification clean

Tracks MALIEV-Co-Ltd/maliev-ops#97.

No application or GitOps manifest is enabled or deployed by this PR.