### PR TITLE
chore: standardize Dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule: { interval: weekly }
+    open-pull-requests-limit: 10
+    groups:
+      nuget-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: { interval: weekly }
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

- configure weekly Dependabot updates only for detected repository ecosystems
- set NuGet/npm limits to 10 and Docker/GitHub Actions limits to 5
- group compatible minor and patch version updates while keeping majors separate
- add no auto-merge behavior

## Validation

- YAML parsed successfully
- policy structure, limits, schedules, grouping, and directories validated
- no runtime or deployment files changed